### PR TITLE
Update NuGet publish workflow to use environment variable for API key

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Push Packages to NuGet
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: dotnet nuget push ./out/*.nupkg -k ${{ NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols
+        run: dotnet nuget push ./out/*.nupkg -k ${{ env.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols


### PR DESCRIPTION
This pull request makes a minor update to the NuGet publishing workflow by changing how the NuGet API key is referenced in the push step. This ensures that the environment variable is accessed correctly during the package publishing process.

- Updated the `dotnet nuget push` command in `.github/workflows/nuget-publish.yml` to use `${{ env.NUGET_API_KEY }}` instead of `${{ secrets.NUGET_API_KEY }}` for the API key reference.## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale / motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
