### PR TITLE
alignment to genocs library

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,27 +1,78 @@
 <Project>
+
+    <!--
+        This Directory.Build.props files sets default properties that apply to all projects found in
+        this folder or subfolders, recursively.
+    -->
     <PropertyGroup>
-        <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)dotnet.ruleset</CodeAnalysisRuleSet>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <NoDefaultExcludes>true</NoDefaultExcludes>
         <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
         <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoDefaultExcludes>true</NoDefaultExcludes>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+        <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)dotnet.ruleset</CodeAnalysisRuleSet>
+        <GenerateDocumentationFile>True</GenerateDocumentationFile>
+        <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+        <Version>1.5.0</Version>
+        <LangVersion>latest</LangVersion>
+        <Company>Genocs</Company>
+        <Copyright>Genocs 2026</Copyright>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <PackageProjectUrl>https://github.com/Genocs/genocs-library-cli</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/Genocs/genocs-library-cli.git</RepositoryUrl>
+        <PackageIcon>icon.png</PackageIcon>
+        <RepositoryType>git</RepositoryType>
+        <EnableNETAnalyzers>True</EnableNETAnalyzers>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <MinClientVersion>5.0.0</MinClientVersion>
+        <Authors>Nocco Giovanni Emanuele</Authors>
+        <PackageReadmeFile>README_NUGET.md</PackageReadmeFile>
+        <AnalysisLevel>latest</AnalysisLevel>
+        <PackageReleaseNotes>
+            The change log and breaking changes are listed here.
+            https://github.com/Genocs/genocs-library-cli/releases
+        </PackageReleaseNotes>
+        <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+        <!--<WarningsAsErrors>$(WarningsAsErrors);nullable</WarningsAsErrors>-->
     </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
             <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+
         <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="Properties\stylecop.json" />
         <AdditionalFiles Include="$(MSBuildThisFileDirectory).editorconfig" Link="Properties\.editorconfig" />
     </ItemGroup>
+
+    <ItemGroup>
+        <None Include="..\..\LICENSE">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </None>
+        <None Include="..\..\icon.png">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </None>
+        <None Include="README_NUGET.md">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </None>
+    </ItemGroup>
+
     <ItemGroup>
         <!-- Define the global DefaultIdType here. -->
         <Using Include="System.Guid" Alias="DefaultIdType" />
     </ItemGroup>
+
+    <PropertyGroup>
+        <!-- Enable Build Acceleration in Visual Studio. -->
+        <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+    </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,6 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <NoDefaultExcludes>true</NoDefaultExcludes>
         <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-        <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
         <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)dotnet.ruleset</CodeAnalysisRuleSet>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
@@ -60,7 +59,7 @@
             <Pack>True</Pack>
             <PackagePath>\</PackagePath>
         </None>
-        <None Include="$(MSBuildThisFileDirectory)README.md">
+        <None Include="README_NUGET.md">
             <Pack>True</Pack>
             <PackagePath>\</PackagePath>
         </None>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <!--
-        This Directory.Build.props files sets default properties that apply to all projects found in
+        This Directory.Build.props file sets default properties that apply to all projects found in
         this folder or subfolders, recursively.
     -->
     <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,15 +52,15 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="..\..\LICENSE">
+        <None Include="$(MSBuildThisFileDirectory)LICENSE">
             <Pack>True</Pack>
             <PackagePath>\</PackagePath>
         </None>
-        <None Include="..\..\icon.png">
+        <None Include="$(MSBuildThisFileDirectory)icon.png">
             <Pack>True</Pack>
             <PackagePath>\</PackagePath>
         </None>
-        <None Include="README_NUGET.md">
+        <None Include="$(MSBuildThisFileDirectory)README.md">
             <Pack>True</Pack>
             <PackagePath>\</PackagePath>
         </None>

--- a/src/GenocsCli/genocs.cli.csproj
+++ b/src/GenocsCli/genocs.cli.csproj
@@ -24,21 +24,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\LICENSE">
-            <Pack>True</Pack>
-            <PackagePath>\</PackagePath>
-        </None>
-        <None Include="..\icon.png">
-            <Pack>True</Pack>
-            <PackagePath>\</PackagePath>
-        </None>
-        <None Include="README_NUGET.md">
-            <Pack>True</Pack>
-            <PackagePath>\</PackagePath>
-        </None>
-    </ItemGroup>
-
-    <ItemGroup>
         <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
     </ItemGroup>
 


### PR DESCRIPTION
This pull request updates the project-wide MSBuild properties and cleans up duplicate packaging metadata. The main focus is on centralizing and enhancing build and packaging settings in `Directory.Build.props`, while removing redundant configuration from the project file.

**Centralization and enhancement of build and packaging settings:**

* Added and updated various MSBuild properties in `Directory.Build.props` to standardize build behavior and NuGet packaging metadata across all projects (e.g., `Version`, `Company`, `Authors`, `RepositoryUrl`, `PackageIcon`, `EnableNETAnalyzers`, `GeneratePackageOnBuild`, etc.).
* Included license, icon, and readme files for NuGet packaging in a shared location, ensuring these assets are packaged for all projects.

**Cleanup of redundant configuration:**

* Removed duplicate packaging asset references from `src/GenocsCli/genocs.cli.csproj`, as these are now handled in `Directory.Build.props`.## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale / motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
